### PR TITLE
Fix typo with title

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## homebridge-lm75a
 
-A Temprature plugin for [HomeBridge](https://github.com/nfarina/homebridge) to read from an [LM75A](http://www.ti.com/product/LM75A) sensor.
+A Temperature plugin for [HomeBridge](https://github.com/nfarina/homebridge) to read from an [LM75A](http://www.ti.com/product/LM75A) sensor.
 
 ## Installation
 


### PR DESCRIPTION
This change fixes a typo with the `readme.md` title.